### PR TITLE
fix: Only match result tag, not intermediate ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           # fake no-op token, image is public
           TOKEN=$(curl https://ghcr.io/token\?scope\="repository:${{ github.repository_owner }}/kubectl:pull" | jq .token | tr -d \")
           if curl -H "Authorization: Bearer $TOKEN" https://ghcr.io/v2/${{ github.repository_owner }}/kubectl/tags/list \
-               | grep ${{ steps.rancher-kubectl.outputs.tag }};
+               | grep \"${{ steps.rancher-kubectl.outputs.tag }}\";
           then
               echo "${{ github.repository_owner }}/kubectl:${{ steps.rancher-kubectl.outputs.tag }} is in repo already"
               echo "image-exists=true" >> $GITHUB_ENV


### PR DESCRIPTION
This makes the job idempotent and more resilient.

The string to evaluate is for example:
`{"name":"kubewarden/kubectl","tags":["v1.23.3-amd64","v1.23.3-arm64","v1.23.3","sha256-f3554ba78df418c816b5e46f5b20071bad27a1dbfe1e7ff153598843fc44a8ba.sig","v1.23.7-amd64"]}`

we want to match `"v1.23.7"` only, not `"v1.23.7-amd64"`.