### PR TITLE
feat: Bump kubectl stable to 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       -
         name: Find latest kubectl version
         run: |
-          KUBECTL_VER="$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt)"
+          KUBECTL_VER="$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.26.txt)"
           echo "kubectl_ver=${KUBECTL_VER}" >> $GITHUB_ENV
       -
         run: echo "kubectl binary is at version ${{ env.kubectl_ver }}"


### PR DESCRIPTION


## Description

Relates to https://github.com/kubewarden/kubewarden-controller/issues/465


This provides support for 1.25, 1.26, 1.27.

A new tag will be released automatically upon merge.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
