### PR TITLE
Updates cosign to v2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-sign:
+    name: "Build and sign kubectl"
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -31,7 +32,7 @@ jobs:
               echo "image-exists=true" >> $GITHUB_ENV
           fi
       -
-        uses: sigstore/cosign-installer@v2.8.1
+        uses: sigstore/cosign-installer@v3
         if: env.image-exists != 'true'
       -
         name: Checkout code
@@ -74,7 +75,5 @@ jobs:
         name: Sign the image
         if: env.image-exists != 'true'
         run: |
-          cosign sign \
+          cosign sign --yes \
             ghcr.io/${{ github.repository_owner }}/kubectl@${{ steps.build-image.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: 1

--- a/download-kubectl.sh
+++ b/download-kubectl.sh
@@ -11,6 +11,8 @@ do
     curl -sSfL https://dl.k8s.io/release/"${1?required}"/bin/linux/"${ARCH}"/kubectl -o kubectl
     curl -sSfL https://dl.k8s.io/release/"${1?required}"/bin/linux/"${ARCH}"/kubectl.sig -o kubectl.sig
     curl -sSfL https://dl.k8s.io/release/"${1?required}"/bin/linux/"${ARCH}"/kubectl.cert -o kubectl.cert
-    COSIGN_EXPERIMENTAL=1 cosign verify-blob kubectl --signature kubectl.sig --certificate kubectl.cert
+    cosign verify-blob --signature kubectl.sig --certificate kubectl.cert kubectl \
+        --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
+        --certificate-oidc-issuer https://accounts.google.com
     popd
 done


### PR DESCRIPTION
## Description

Updates the CI scripts updating the cosign-installer to v3. Thus, the cosign version now is v2. Which has breaking changes requiring some changes on how the command is called and removing the need of using environment variable to enable keyless signature.


Related to https://github.com/kubewarden/kubewarden-controller/issues/411